### PR TITLE
Add inspec winrm script

### DIFF
--- a/recipes/functional.rb
+++ b/recipes/functional.rb
@@ -45,8 +45,8 @@ with_server_config do
     when 'windows'
       winrm_user = inspec_data['inspec']['winrm-user']
       winrm_password = inspec_data['inspec']['winrm-password']
-      file "#{workflow_workspace_repo}/#{workflow_phase}/#{workflow_stage}/repo/inspec-winrm.sh" do
-        content "Hello"
+      file "#{workflow_workspace_repo}/inspec-winrm.sh" do
+        content 'Hello'
       end
       execute 'execute_functional_inspec' do
         command '/opt/chefdk/embedded/bin/inspec ' \

--- a/recipes/functional.rb
+++ b/recipes/functional.rb
@@ -46,14 +46,16 @@ with_server_config do
       winrm_user = inspec_data['inspec']['winrm-user']
       winrm_password = inspec_data['inspec']['winrm-password']
       file "#{workflow_workspace_repo}/inspec-winrm.sh" do
-        content 'Hello'
-      end
-      execute 'execute_functional_inspec' do
-        command '/opt/chefdk/embedded/bin/inspec ' \
+        content '/opt/chefdk/embedded/bin/inspec ' \
                   "exec #{node['delivery']['workspace']['repo']}"\
                   '/test/recipes/ ' \
                   "-t winrm://#{winrm_user}@#{infra_node['ipaddress']} " \
                   "--password '#{winrm_password}'"
+        sensitive true
+        mode '0750'
+      end
+      execute 'execute_functional_inspec' do
+        command "#{workflow_workspace_repo}/inspec-winrm.sh"
         action :run
         live_stream true
       end

--- a/recipes/functional.rb
+++ b/recipes/functional.rb
@@ -45,6 +45,9 @@ with_server_config do
     when 'windows'
       winrm_user = inspec_data['inspec']['winrm-user']
       winrm_password = inspec_data['inspec']['winrm-password']
+      file "#{workflow_workspace_repo}/#{workflow_phase}/#{workflow_stage}/repo/inspec-winrm.sh" do
+        content "Hello"
+      end
       execute 'execute_functional_inspec' do
         command '/opt/chefdk/embedded/bin/inspec ' \
                   "exec #{node['delivery']['workspace']['repo']}"\


### PR DESCRIPTION
This change makes the winrm call to inspec inside of a script, which keeps the winrm password from being logged.

Fixes #1 